### PR TITLE
showing the author names as “first_name last_name” (without comma) in…

### DIFF
--- a/Classes/Utility/Labels.php
+++ b/Classes/Utility/Labels.php
@@ -1,0 +1,21 @@
+<?php
+namespace In2code\Publications\Utility;
+
+class Labels
+{
+    /**
+     * returns the main label for each author in the backend table view of all db entries,
+     * in this case "first_name last_name"
+     * @return void
+     */
+    function getAuthorLabel(&$params, &$pObj)
+    {
+        if ($params['table'] != 'tx_publications_domain_model_author') {
+            return '';
+        }
+        // get complete record
+        $rec = \TYPO3\CMS\Backend\Utility\BackendUtility::getRecord($params['table'], $params['row']['uid']);
+        // write to the label
+        $params['title'] = $rec['first_name'] . ' ' . $rec['last_name'];
+    }
+}

--- a/Configuration/TCA/tx_publications_domain_model_author.php
+++ b/Configuration/TCA/tx_publications_domain_model_author.php
@@ -4,9 +4,8 @@ use In2code\Publications\Domain\Model\Author;
 $tca = [
     'ctrl' => [
         'title' => 'LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:' . Author::TABLE_NAME,
-        'label' => 'first_name',
-        'label_alt' => 'last_name',
-        'label_alt_force' => true,
+        'label' => 'last_name',
+        'label_userFunc' => 'In2code\\Publications\\Utility\\Labels->getAuthorLabel',
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'cruser_id' => 'cruser_id',


### PR DESCRIPTION
showing the author names as “first_name last_name” (without comma) in the list module table as well as in the Publication form, section “Relations”; sorting the table by clicking the column header now sorts by last_name (which was the default sorting anyway)