### PR TITLE
Fix icon html errors

### DIFF
--- a/Classes/ViewHelpers/Render/IconViewHelper.php
+++ b/Classes/ViewHelpers/Render/IconViewHelper.php
@@ -35,12 +35,12 @@ class IconViewHelper extends AbstractViewHelper
             case 'docx':
             $iconCode = '<img src="/typo3conf/ext/publications/Resources/Public/Icons/docx.svg" '
                 . $this->buildAttributes()
-                . ';">';
+                . ' alt="'. $fileType .'">';
             break;
             case 'pdf':
                 $iconCode = '<img src="/typo3conf/ext/publications/Resources/Public/Icons/pdf.svg" '
                     . $this->buildAttributes()
-                    . ';">';
+                    . ' alt="'. $fileType .'">';
                 break;
         }
 


### PR DESCRIPTION
The generated HTML for icons is not valid:

`<img src="/typo3conf/ext/publications/Resources/Public/Icons/pdf.svg" ;">`

* There is a `;"` that doesn't match any start attribute
* the mandatory `alt` attribute is missing

This merge request fixes both errors