### PR TITLE
[FEATURE] Group Link header option

### DIFF
--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -30,6 +30,21 @@
 							</config>
 						</TCEforms>
 					</settings.hideEnumeration>
+					<settings.showGroupLinks>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.showGroupLinks</label>
+							<config>
+								<type>check</type>
+								<default>0</default>
+								<items type="array">
+										<numIndex index="0" type="array">
+											<numIndex index="0">LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.showGroupLinks.label</numIndex>
+										</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.showGroupLinks>
 					<settings.citestyle>
 						<TCEforms>
 							<exclude>1</exclude>
@@ -52,6 +67,10 @@
 								<type>select</type>
 								<renderType>selectSingle</renderType>
 								<items type="array">
+									<numIndex index="-1" type="array">
+										<numIndex index="0">LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.groupby.-1</numIndex>
+										<numIndex index="1">-1</numIndex>
+									</numIndex>
 									<numIndex index="0" type="array">
 										<numIndex index="0">LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.groupby.0</numIndex>
 										<numIndex index="1">0</numIndex>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -558,6 +558,10 @@
 				<source>Group by</source>
 				<target state="translated">Gruppieren nach</target>
 			</trans-unit>
+			<trans-unit id="flexform.pi1.template.groupby.-1">
+				<source>none</source>
+				<target state="translated">Keine Grupierung</target>
+			</trans-unit>
 			<trans-unit id="flexform.pi1.template.groupby.0">
 				<source>year</source>
 				<target state="translated">Jahr</target>
@@ -594,7 +598,14 @@
 				<source>Hide enumeration?</source>
 				<target state="translated">Nummerierung verbergen?</target>
 			</trans-unit>
-
+			<trans-unit id="flexform.pi1.template.showGroupLinks">
+				<source>Header with Links</source>
+				<target state="translated">Kopfleiste mit Links</target>
+			</trans-unit>
+			<trans-unit id="flexform.pi1.template.showGroupLinks.label">
+				<source>Display links to grouped sections. Only active when 'Group by' selected. </source>
+				<target state="translated">Links zu groupierten Kapitel anzeigen. Nur aktiv wenn 'Grupieren nach' ausgewählt.</target>
+			</trans-unit>
 			<trans-unit id="backendModule.selectImportFormat">
 				<target>Format für Import auswählen</target>
 			</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -421,6 +421,9 @@
 			<trans-unit id="flexform.pi1.template.groupby">
 				<source>Group by</source>
 			</trans-unit>
+			<trans-unit id="flexform.pi1.template.groupby.-1">
+				<source>none</source>
+			</trans-unit>
 			<trans-unit id="flexform.pi1.template.groupby.0">
 				<source>year</source>
 			</trans-unit>
@@ -448,7 +451,12 @@
 			<trans-unit id="flexform.pi1.template.hideEnumeration">
 				<source>Hide enumeration?</source>
 			</trans-unit>
-
+			<trans-unit id="flexform.pi1.template.showGroupLinks">
+				<source>Header with Links</source>
+			</trans-unit>
+			<trans-unit id="flexform.pi1.template.showGroupLinks.label">
+				<source>Display links to grouped sections. Only active when 'Group by' selected. </source>
+			</trans-unit>
 			<trans-unit id="backendModule.selectImportFormat">
 				<source>Select Import Format</source>
 			</trans-unit>

--- a/Resources/Private/Partials/List/GroupLinks.html
+++ b/Resources/Private/Partials/List/GroupLinks.html
@@ -1,0 +1,24 @@
+<div id="grouplinks" style="padding: 15px 0;">
+	<f:if condition="{publications}">
+					<f:for each="{publications}" as="publication">
+							<f:render section="GroupLink" arguments="{_all}"/>
+					</f:for>
+	</f:if>
+</div>
+
+
+
+
+<f:section name="GroupLink">
+	<f:switch expression="{filter.groupby}">
+		<f:case value="0">
+			<publications:group.title title="{publication.year}" singeltonKey="grouplink" before='[<a href="#{publication.year}">' after='</a>] &nbsp;' />
+		</f:case>
+		<f:case value="1">
+			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="grouplink" before='[<a href="#{publication.bibtype}">' after='</a>] &nbsp;'  />
+		</f:case>
+		<f:case value="2">
+			<publications:group.title title="{publication.year}" singeltonKey="grouplink" before='[<a href="#{publication.year}">' after='</a>] &nbsp;' />
+		</f:case>
+	</f:switch>
+</f:section>

--- a/Resources/Private/Partials/List/GroupLinks.html
+++ b/Resources/Private/Partials/List/GroupLinks.html
@@ -1,8 +1,8 @@
-<div id="grouplinks" style="padding: 15px 0;">
+<div id="grouplinks-{data.uid}" style="padding: 15px 0;">
 	<f:if condition="{publications}">
-					<f:for each="{publications}" as="publication">
-							<f:render section="GroupLink" arguments="{_all}"/>
-					</f:for>
+		<f:for each="{publications}" as="publication">
+			<f:render section="GroupLink" arguments="{_all}"/>
+		</f:for>
 	</f:if>
 </div>
 
@@ -12,13 +12,13 @@
 <f:section name="GroupLink">
 	<f:switch expression="{filter.groupby}">
 		<f:case value="0">
-			<publications:group.title title="{publication.year}" singeltonKey="grouplink" before='[<a href="#{publication.year}">' after='</a>] &nbsp;' />
+			<publications:group.title title="{publication.year}" singeltonKey="grouplink-{data.uid}" before='[<a href="#c{publication.year}-{data.uid}">' after='</a>] &nbsp;' />
 		</f:case>
 		<f:case value="1">
-			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="grouplink" before='[<a href="#{publication.bibtype}">' after='</a>] &nbsp;'  />
+			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="grouplink-{data.uid}" before='[<a href="#{publication.bibtype}-{data.uid}">' after='</a>] &nbsp;'  />
 		</f:case>
 		<f:case value="2">
-			<publications:group.title title="{publication.year}" singeltonKey="grouplink" before='[<a href="#{publication.year}">' after='</a>] &nbsp;' />
+			<publications:group.title title="{publication.year}" singeltonKey="grouplink-{data.uid}" before='[<a href="#c{publication.year}-{data.uid}">' after='</a>] &nbsp;' />
 		</f:case>
 	</f:switch>
 </f:section>

--- a/Resources/Private/Templates/Publication/List.html
+++ b/Resources/Private/Templates/Publication/List.html
@@ -1,7 +1,5 @@
 <f:layout name="Frontend"/>
 
-
-
 <f:section name="Content">
 	<f:if condition="{settings.hideFilter} != true">
 		<f:render partial="List/Filter" arguments="{_all}"/>
@@ -43,14 +41,14 @@
 <f:section name="GroupTitle">
 	<f:switch expression="{filter.groupby}">
 		<f:case value="0">
-			<publications:group.title title="{publication.year}" before='<h4 id="c{publication.year}">' after="</h4>" />
+			<publications:group.title title="{publication.year}" singeltonKey="{publication.year}-{data.uid}" before='<h4 id="c{publication.year}-{data.uid}">' after="</h4>" />
 		</f:case>
 		<f:case value="1">
-			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" before='<h4 id="{publication.bibtype}">' after="</h4>" />
+			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="{publication.bibtype}-{data.uid}" before='<h4 id="{publication.bibtype}-{data.uid}">' after="</h4>" />
 		</f:case>
 		<f:case value="2">
-			<publications:group.title title="{publication.year}" before='<h4 id="c{publication.year}">' after="</h4>" />
-			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="{publication.year}{publication.bibtype}" before="<h5>" after="</h5>" />
+			<publications:group.title title="{publication.year}" singeltonKey="{publication.year}-{data.uid}" before='<h4 id="c{publication.year}-{data.uid}">' after="</h4>" />
+			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="{publication.year}{publication.bibtype}-{data.uid}" before="<h5>" after="</h5>" />
 		</f:case>
 	</f:switch>
 </f:section>

--- a/Resources/Private/Templates/Publication/List.html
+++ b/Resources/Private/Templates/Publication/List.html
@@ -39,13 +39,13 @@
 <f:section name="GroupTitle">
 	<f:switch expression="{filter.groupby}">
 		<f:case value="0">
-			<publications:group.title title="{publication.year}" before="<h4>" after="</h4>" />
+			<publications:group.title title="{publication.year}" before='<h4 id="{publication.year}">' after="</h4>" />
 		</f:case>
 		<f:case value="1">
-			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" before="<h4>" after="</h4>" />
+			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" before='<h4 id="{publication.bibtype}">' after="</h4>" />
 		</f:case>
 		<f:case value="2">
-			<publications:group.title title="{publication.year}" before="<h4>" after="</h4>" />
+			<publications:group.title title="{publication.year}" before='<h4 id="{publication.year}">' after="</h4>" />
 			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="{publication.year}{publication.bibtype}" before="<h5>" after="</h5>" />
 		</f:case>
 	</f:switch>

--- a/Resources/Private/Templates/Publication/List.html
+++ b/Resources/Private/Templates/Publication/List.html
@@ -4,7 +4,11 @@
 
 <f:section name="Content">
 	<f:if condition="{settings.hideFilter} != true">
-	<f:render partial="List/Filter" arguments="{_all}"/>
+		<f:render partial="List/Filter" arguments="{_all}"/>
+	</f:if>
+
+	<f:if condition="{settings.showGroupLinks} == true">
+		<f:render partial="List/GroupLinks" arguments="{_all}"/>
 	</f:if>
 
 	<f:if condition="{publications}">
@@ -39,13 +43,13 @@
 <f:section name="GroupTitle">
 	<f:switch expression="{filter.groupby}">
 		<f:case value="0">
-			<publications:group.title title="{publication.year}" before='<h4 id="{publication.year}">' after="</h4>" />
+			<publications:group.title title="{publication.year}" before='<h4 id="c{publication.year}">' after="</h4>" />
 		</f:case>
 		<f:case value="1">
 			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" before='<h4 id="{publication.bibtype}">' after="</h4>" />
 		</f:case>
 		<f:case value="2">
-			<publications:group.title title="{publication.year}" before='<h4 id="{publication.year}">' after="</h4>" />
+			<publications:group.title title="{publication.year}" before='<h4 id="c{publication.year}">' after="</h4>" />
 			<publications:group.title title="{f:translate(key:'bibtype.{publication.bibtype}',default:publication.bibtype)}" singeltonKey="{publication.year}{publication.bibtype}" before="<h5>" after="</h5>" />
 		</f:case>
 	</f:switch>


### PR DESCRIPTION
This package adds the option to have links to group sections at the top of a reference list. 

This is useful for long lists on the same page (multiple pages not yet supported)

In addition, it adds the option to have no grouping (-1), mostly useful when filters are activated. 

To add the header option, enable the checkmark in the flexform. 