### PR TITLE
[FEATURE] uses links if name is activated

### DIFF
--- a/Classes/Domain/Model/Author.php
+++ b/Classes/Domain/Model/Author.php
@@ -27,6 +27,11 @@ class Author extends AbstractEntity
     protected $url = '';
 
     /**
+     * @var string
+     */
+    protected $orcid = '';
+
+    /**
      * @return string
      */
     public function getLastName(): string
@@ -77,6 +82,24 @@ class Author extends AbstractEntity
     public function setUrl(string $url): self
     {
         $this->url = $url;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getORCID(): string
+    {
+        return $this->orcid;
+    }
+
+    /**
+     * @param string $url
+     * @return Author
+     */
+    public function setORCID(string $orcid): self
+    {
+        $this->orcid = $orcid;
         return $this;
     }
 }

--- a/Classes/Domain/Model/Author.php
+++ b/Classes/Domain/Model/Author.php
@@ -88,7 +88,7 @@ class Author extends AbstractEntity
     /**
      * @return string
      */
-    public function getORCID(): string
+    public function getOrcid(): string
     {
         return $this->orcid;
     }
@@ -97,7 +97,7 @@ class Author extends AbstractEntity
      * @param string $url
      * @return Author
      */
-    public function setORCID(string $orcid): self
+    public function setOrcid(string $orcid): self
     {
         $this->orcid = $orcid;
         return $this;

--- a/Configuration/FlexForms/FlexFormPi1.xml
+++ b/Configuration/FlexForms/FlexFormPi1.xml
@@ -105,6 +105,21 @@
 							</config>
 						</TCEforms>
 					</settings.recordsPerPage>
+					<settings.linkNames>
+						<TCEforms>
+							<exclude>1</exclude>
+							<label>LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.linkNames</label>
+							<config>
+								<type>check</type>
+								<default>0</default>
+								<items type="array">
+									<numIndex index="0" type="array">
+										<numIndex index="0">LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:flexform.pi1.template.linkNames.label</numIndex>
+									</numIndex>
+								</items>
+							</config>
+						</TCEforms>
+					</settings.linkNames>
 					<settings.export>
 						<TCEforms>
 							<exclude>1</exclude>

--- a/Configuration/TCA/tx_publications_domain_model_author.php
+++ b/Configuration/TCA/tx_publications_domain_model_author.php
@@ -19,7 +19,7 @@ $tca = [
         'default_sortby' => 'ORDER BY last_name ASC',
         'delete' => 'deleted',
         'iconfile' => 'EXT:publications/Resources/Public/Icons/' . Author::TABLE_NAME . '.svg',
-        'searchFields' => 'last_name,first_name,url'
+        'searchFields' => 'last_name,first_name,url,orcid'
     ],
     'interface' => [
         'showRecordFieldList' => 'will be filled below...',
@@ -27,7 +27,7 @@ $tca = [
     'types' => [
         '1' => [
             'showitem' =>
-                '--palette--;;palette_author,url,--div--;' . $llTable . '.tab.system,--palette--;;palette_system,'
+                '--palette--;;palette_author,url,orcid,--div--;' . $llTable . '.tab.system,--palette--;;palette_system,'
         ],
     ],
     'palettes' => [
@@ -111,6 +111,16 @@ $tca = [
             'exclude' => true,
             'label' => 'LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:' . Author::TABLE_NAME
                 . '.first_name',
+            'config' => [
+                'type' => 'input',
+                'eval' => 'trim',
+                'default' => ''
+            ]
+        ],
+        'orcid' => [
+            'exclude' => true,
+            'label' => 'LLL:EXT:publications/Resources/Private/Language/locallang_db.xlf:' . Author::TABLE_NAME
+                . '.orcid',
             'config' => [
                 'type' => 'input',
                 'eval' => 'trim',

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -266,6 +266,9 @@
 			<trans-unit id="tx_publications_domain_model_author.url">
 				<source>URL</source>
 			</trans-unit>
+			<trans-unit id="tx_publications_domain_model_author.orcid">
+				<source>ORCID</source>
+			</trans-unit>
 			<trans-unit id="tx_publications_domain_model_author.tab.system">
 				<source>System</source>
 			</trans-unit>
@@ -459,6 +462,13 @@
 			</trans-unit>
 			<trans-unit id="flexform.pi1.template.hideEnumeration">
 				<source>Hide enumeration?</source>
+			</trans-unit>
+
+			<trans-unit id="flexform.pi1.template.linkNames">
+				<source>Link names</source>
+			</trans-unit>
+			<trans-unit id="flexform.pi1.template.linkNames.label">
+				<source>Adds a link where name URL or ORCID database entry is set.</source>
 			</trans-unit>
 			<trans-unit id="flexform.pi1.template.showGroupLinks">
 				<source>Header with Links</source>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -375,8 +375,13 @@
 
 <f:section name="authors">
 	<f:for each="{publication.authors}" as="author" iteration="iteration">
-		{author.lastName}<f:if condition="{author.lastName} && {author.firstName}">,</f:if>
-		{author.firstName}<f:if condition="{iteration.isLast} == 0">;</f:if>
+	<f:if condition="{author.url} && {settings.linkNames}">
+		<f:then> <a href="{author.url}" target="_self"></f:then>
+	  <f:else if="{author.orcid} && {settings.linkNames}"><a href="https://orcid.org/{author.orcid}" target="_blank"></f:else></f:if>
+			{author.lastName}<f:if condition="{author.lastName} && {author.firstName}">,</f:if>
+			{author.firstName}<f:if condition="{iteration.isLast} == 0">;</f:if>
+			<f:if condition="{author.url} && {settings.linkNames}"><f:then></a></f:then>
+		 <f:else if="{author.orcid} && {settings.linkNames}"></a></f:else></f:if>
 	</f:for>
 </f:section>
 

--- a/Resources/Private/Partials/List/Citestyle/Citestyle1.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle1.html
@@ -12,6 +12,15 @@
 	</div>
 </div>
 
+<f:section name="bibtype_incollection">
+	<f:render section="bibtype_inbook" arguments="{_all}"/>
+</f:section>
+
+
+<f:section name="bibtype_inproceedings">
+	<f:render section="bibtype_conference" arguments="{_all}"/>
+</f:section>
+
 
 <f:section name="bibtype_article">
 	<f:if condition="{publication.language}">[{publication.language}]</f:if>
@@ -102,14 +111,7 @@
 </f:section>
 
 
-<f:section name="bibtype_incollection">
-	<f:render section="bibtype_inbook" arguments="{_all}"/>
-</f:section>
 
-
-<f:section name="bibtype_inproceedings">
-	<f:render section="bibtype_conference" arguments="{_all}"/>
-</f:section>
 
 
 <f:section name="bibtype_manual">
@@ -255,33 +257,38 @@
 <f:section name="authors">
 	<f:for each="{publication.authors}" as="author" iteration="iteration">
 		<f:if condition="{publication.authors -> f:count()} == 1">
-			<publications:format.initials>{author.firstName}</publications:format.initials>
-			{author.lastName},
+				<f:render section="namestring"  arguments="{_all}"/>,
 		</f:if>
 		<f:if condition="{publication.authors -> f:count()} == 2">
 			<f:if condition="{iteration.isFirst}">
-				<publications:format.initials>{author.firstName}</publications:format.initials>
-				{author.lastName} and
+				<f:render section="namestring"  arguments="{_all}"/> and
 			</f:if>
 			<f:if condition="{iteration.isLast}">
-				<publications:format.initials>{author.firstName}</publications:format.initials>
-				{author.lastName},
+				<f:render section="namestring"  arguments="{_all}"/>,
 			</f:if>
 		</f:if>
 		<f:if condition="{publication.authors -> f:count()} > 2">
 			<f:comment>If author is last before</f:comment>
 			<f:if condition="{iteration.cycle + 1} == {publication.authors -> f:count()}">
 				<f:then>
-					<publications:format.initials>{author.firstName}</publications:format.initials>
-					{author.lastName} and
+					<f:render section="namestring"  arguments="{_all}"/> and
 				</f:then>
 				<f:else>
-					<publications:format.initials>{author.firstName}</publications:format.initials>
-					{author.lastName},
+					<f:render section="namestring"  arguments="{_all}"/>,
 				</f:else>
 			</f:if>
 		</f:if>
 	</f:for>
+</f:section>
+
+
+<f:section name="namestring">
+	<f:if condition="{author.url} && {settings.linkNames}">
+		<f:then> <a href="{author.url}" target="_self"></f:then>
+			<f:else if="{author.orcid} && {settings.linkNames}"><a href="https://orcid.org/{author.orcid}" target="_blank"></f:else></f:if>
+	<publications:format.initials>{author.firstName}</publications:format.initials>{author.lastName}
+	<f:if condition="{author.url} && {settings.linkNames}"><f:then></a></f:then>
+ <f:else if="{author.orcid} && {settings.linkNames}"></a></f:else></f:if>
 </f:section>
 
 </html>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle4.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle4.html
@@ -518,49 +518,51 @@
 
 <f:comment>
 	Pohl, S.
-	Pohl, S. and Kellner, A.
-	Pohl, S., Kellner, A., Muster, M. and Stein, S.
+	Pohl, S. & Kellner, A.
+	Pohl, S., Kellner, A., Muster, M. & Stein, S.
 </f:comment>
 
 <f:section name="authors">
 	<f:for each="{publication.authors}" as="author" iteration="iteration">
 		<f:if condition="{publication.authors -> f:count()} == 1">
-			{author.lastName},
-			<publications:format.initials>{author.firstName}</publications:format.initials>
+			<f:render section="namestring"  arguments="{_all}"/>
 		</f:if>
 		<f:if condition="{publication.authors -> f:count()} == 2">
 			<f:if condition="{iteration.isFirst}">
-				{author.lastName},
-				<publications:format.initials>{author.firstName}</publications:format.initials>, &
+				<f:render section="namestring"  arguments="{_all}"/>, &
 			</f:if>
 			<f:if condition="{iteration.isLast}">
-				{author.lastName},
-				<publications:format.initials>{author.firstName}</publications:format.initials>
+				<f:render section="namestring"  arguments="{_all}"/>
 			</f:if>
 		</f:if>
 		<f:if condition="{publication.authors -> f:count()} > 2">
 			<f:comment>If author is last before</f:comment>
 			<f:if condition="{iteration.cycle + 1} == {publication.authors -> f:count()}">
 				<f:then>
-					{author.lastName},
-					<publications:format.initials>{author.firstName}</publications:format.initials>, &
+					<f:render section="namestring"  arguments="{_all}"/>, &
 				</f:then>
 				<f:else>
 					<f:if condition="{iteration.isLast}">
 						<f:then>
-							{author.lastName},
-							<publications:format.initials>{author.firstName}</publications:format.initials>
+							<f:render section="namestring"  arguments="{_all}"/>
 						</f:then>
 						<f:else>
-							{author.lastName},
-							<publications:format.initials>{author.firstName}</publications:format.initials>,
+							<f:render section="namestring"  arguments="{_all}"/>,
 						</f:else>
 					</f:if>
 				</f:else>
 			</f:if>
-
 		</f:if>
 	</f:for>
+</f:section>
+
+<f:section name="namestring">
+	<f:if condition="{author.url} && {settings.linkNames}">
+		<f:then> <a href="{author.url}" target="_self"></f:then>
+			<f:else if="{author.orcid} && {settings.linkNames}"><a href="https://orcid.org/{author.orcid}" target="_blank"></f:else></f:if>
+				{author.lastName}, <publications:format.initials>{author.firstName}</publications:format.initials>
+	<f:if condition="{author.url} && {settings.linkNames}"><f:then></a></f:then>
+ <f:else if="{author.orcid} && {settings.linkNames}"></a></f:else></f:if>
 </f:section>
 
 </html>

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -77,6 +77,7 @@ CREATE TABLE tx_publications_domain_model_author (
 	first_name varchar(255) DEFAULT '' NOT NULL,
 	last_name varchar(255) DEFAULT '' NOT NULL,
 	url varchar(255) DEFAULT '' NOT NULL,
+	orcid varchar(255) DEFAULT '' NOT NULL,
 
 	tstamp int(11) unsigned DEFAULT '0' NOT NULL,
 	crdate int(11) unsigned DEFAULT '0' NOT NULL,


### PR DESCRIPTION
This feature adds 

- ORCID in authors db table. ORCID is a universal identifier for scientific authors. 
- use of url and ORCID to link author names in citations and reference lists

this pull request also addresses #25 

**TODO**

- imports do not yet support ORCID
- flexform does not yet support internal links for author url