### PR TITLE
[BUGFIX] fix no returned publications if documenttype filter set to all

### DIFF
--- a/Classes/Domain/Model/Dto/Filter.php
+++ b/Classes/Domain/Model/Dto/Filter.php
@@ -81,7 +81,7 @@ class Filter
     /**
      * @var string
      */
-    protected $documenttype = '';
+    protected string $documenttype = 'all';
 
     /**
      * @var int


### PR DESCRIPTION
there will be an unnecessary query constraint because the default value of $documenttype in a filter object is '' instead of 'all'