### PR TITLE
Add grouplink css class instead of  brackets

### DIFF
--- a/Resources/Private/Partials/List/GroupLinks.html
+++ b/Resources/Private/Partials/List/GroupLinks.html
@@ -1,7 +1,7 @@
 <div id="grouplinks-{data.uid}" style="padding: 15px 0;">
 	<f:if condition="{groupLinks}">
 		<f:for each="{groupLinks}" as="group">
-      [<a href="{group.link}">{group.title}</a>] &nbsp;
+      <a class="grouplink" href="{group.link}">{group.title}</a> &nbsp;
 		</f:for>
 	</f:if>
 </div>


### PR DESCRIPTION
offers more flexibility to format the grouplinks. 

add 

```
.grouplink::before {
  content: "[";
}
.grouplink::after {
  content: "]";
}
```

to css for backwards compatibility