### PR TITLE
[TASK] replace TCA property wizards with fieldControl

### DIFF
--- a/Configuration/TCA/tx_publications_domain_model_author.php
+++ b/Configuration/TCA/tx_publications_domain_model_author.php
@@ -140,23 +140,20 @@ $tca = [
                 . '.url',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputLink',
                 'eval' => 'trim',
                 'default' => '',
-                'wizards' => [
-                    'link' => [
-                        'type' => 'popup',
+                'fieldControl' => [
+                    'linkPopup' => [
+                      'options' => [
                         'title' => 'URL',
-                        'icon' => 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif',
-                        'module' => [
-                            'name' => 'wizard_link',
-                        ],
-                        'JSopenParams' => 'height=800,width=600,status=0,menubar=0,scrollbars=1'
-                    ]
+                      ],
+                    ],
                 ],
-                'softref' => 'typolink'
-            ]
+              'softref' => 'typolink',
+            ],
         ],
-    ]
+    ],
 ];
 
 $tca['interface']['showRecordFieldList'] = implode(',', array_keys($tca['columns']));

--- a/Configuration/TCA/tx_publications_domain_model_publication.php
+++ b/Configuration/TCA/tx_publications_domain_model_publication.php
@@ -497,63 +497,54 @@ $tca = [
             'label' => $llTable . '.file_url',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputLink',
                 'eval' => 'trim',
                 'default' => '',
-                'wizards' => [
-                    'link' => [
-                        'type' => 'popup',
-                        'title' => 'URL',
-                        'icon' => 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif',
-                        'module' => [
-                            'name' => 'wizard_link',
-                        ],
-                        'JSopenParams' => 'height=800,width=600,status=0,menubar=0,scrollbars=1'
-                    ]
+                'softref' => 'typolink',
+                'fieldControl' => [
+                  'linkPopup' => [
+                    'options' => [
+                      'title' => 'URL',
+                    ],
+                  ],
                 ],
-                'softref' => 'typolink'
-            ]
+            ],
         ],
         'web_url' => [
             'exclude' => true,
             'label' => $llTable . '.web_url',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputLink',
                 'eval' => 'trim',
                 'default' => '',
-                'wizards' => [
-                    'link' => [
-                        'type' => 'popup',
-                        'title' => 'URL',
-                        'icon' => 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif',
-                        'module' => [
-                            'name' => 'wizard_link',
-                        ],
-                        'JSopenParams' => 'height=800,width=600,status=0,menubar=0,scrollbars=1'
-                    ]
+                'softref' => 'typolink',
+                'fieldControl' => [
+                  'linkPopup' => [
+                    'options' => [
+                      'title' => 'URL',
+                    ],
+                  ],
                 ],
-                'softref' => 'typolink'
-            ]
+            ],
         ],
         'web_url2' => [
             'exclude' => true,
             'label' => $llTable . '.web_url2',
             'config' => [
                 'type' => 'input',
+                'renderType' => 'inputLink',
                 'eval' => 'trim',
                 'default' => '',
-                'wizards' => [
-                    'link' => [
-                        'type' => 'popup',
-                        'title' => 'URL',
-                        'icon' => 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_link.gif',
-                        'module' => [
-                            'name' => 'wizard_link',
-                        ],
-                        'JSopenParams' => 'height=800,width=600,status=0,menubar=0,scrollbars=1'
-                    ]
+                'softref' => 'typolink',
+                'fieldControl' => [
+                  'linkPopup' => [
+                    'options' => [
+                      'title' => 'URL',
+                    ],
+                  ],
                 ],
-                'softref' => 'typolink'
-            ]
+            ],
         ],
         'web_url_date' => [
             'exclude' => true,
@@ -811,19 +802,12 @@ $tca = [
                 'MM' => 'tx_publications_publication_author_mm',
                 'maxitems' => 9999,
                 'size' => 10,
-                'wizards' => [
-                    'edit' => [
-                        'type' => 'popup',
-                        'title' => 'Edit',
-                        'popup_onlyOpenIfSelected' => 1,
-                        'JSopenParams' => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
-                        'module' => [
-                            'name' => 'wizard_edit',
-                        ],
-                        'icon' => 'EXT:backend/Resources/Public/Images/FormFieldWizard/wizard_edit.gif'
-                    ]
-                ]
-            ]
+                'fieldControl' => [
+                  'editPopup' => [
+                    'disabled' => false,
+                  ],
+                ],
+            ],
         ],
         'patent' => [
         'displayCond' => 'FIELD:bibtype:=:patent',


### PR DESCRIPTION
replaced TCA property wizards because it is deprecated: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/8.6/Deprecation-79440-TcaChanges.html

It is removed in TYPO3v11, so the wizards aren't shown anymore.