### PR TITLE
[BUGFIX] Use spaceship operator to compare publications DateTime

### DIFF
--- a/Classes/Domain/Repository/PublicationRepository.php
+++ b/Classes/Domain/Repository/PublicationRepository.php
@@ -335,6 +335,6 @@ class PublicationRepository extends AbstractRepository
      */
     public function compareCallbackByDate(Publication $p1, Publication $p2): int
     {
-        return strnatcmp((string)$p2->getDate()->format('U'), (string)$p1->getDate()->format('U'));
+        return $p2->getDate() <=> $p1->getDate();
     }
 }


### PR DESCRIPTION
Fixes https://github.com/in2code-de/publications/issues/59

`strnatcmp` is not meant to compare integers and will always deliver wrong results for negative integer values. Since PHP7, the Spaceship operator is able to perform comparisons between two DateTime objects.