### PR TITLE
[usability] increase input field display length

### DIFF
--- a/Configuration/TCA/tx_publications_domain_model_publication.php
+++ b/Configuration/TCA/tx_publications_domain_model_publication.php
@@ -353,6 +353,7 @@ $tca = [
             'label' => $llTable . '.title',
             'config' => [
                 'type' => 'input',
+                'size' => 50,
                 'eval' => 'trim,required',
                 'default' => ''
             ]
@@ -596,6 +597,7 @@ $tca = [
             'label' => $llTable . '.series',
             'config' => [
                 'type' => 'input',
+                'size' => 50,
                 'eval' => 'trim',
                 'default' => ''
             ]
@@ -677,6 +679,7 @@ $tca = [
             'label' => $llTable . '.event_name',
             'config' => [
                 'type' => 'input',
+                'size' => 50,
                 'eval' => 'trim',
                 'default' => ''
             ]
@@ -715,6 +718,7 @@ $tca = [
             'label' => $llTable . '.booktitle',
             'config' => [
                 'type' => 'input',
+                'size' => 50,
                 'eval' => 'trim',
                 'default' => ''
             ]


### PR DESCRIPTION
Increase field display length from default (30) to max possible value (50) for title fields. It was difficult to edit in backend previously.