### PR TITLE
[BUGFIX] Correct sorting within the year from newest/latest to oldest

### DIFF
--- a/Classes/Domain/Model/Publication.php
+++ b/Classes/Domain/Model/Publication.php
@@ -448,7 +448,10 @@ class Publication extends AbstractEntity
      */
     public function getMonth(): string
     {
-        return $this->month;
+        if (!is_numeric($this->month)) {
+            return (string) (date_parse($this->month)['month'] ?: '');
+        }
+        return (string) ((int) $this->month);
     }
 
     /**


### PR DESCRIPTION
Innerhalb der Jahre ist die Sortierung irgendwie ein wenig durcheinandergemischt. Die Sortierung haben wir so angepasst, sodass diese jetzt vom neusten zum ältesten Eintrag runter läuft.
```
[2022 =>
   [July]
   [June]
   [May]
   [April]
   [January]
]
```

-----

Within the years the sorting is somehow a little mixed up. We have adjusted the sorting so that it now runs down from the newest/latest to the oldest entry.

```
[2022 =>
   [July]
   [June]
   [May]
   [April]
   [January]
]
```