### PR TITLE
[BUGFIX] Make module available in module selection for backend user groups

### DIFF
--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -4,7 +4,7 @@ return [
     'web_publications' => [
         'parent' => 'web',
         'position' => [],
-        'access' => 'user, group',
+        'access' => 'user',
         'icon' => 'EXT:publications/Resources/Public/Icons/ModuleImport.svg',
         'labels' => 'LLL:EXT:publications/Resources/Private/Language/locallang_mod_import.xlf',
         'path' => '/module/web/publications',


### PR DESCRIPTION
When giving editor backend users permissions to access the Publication module, it's not possible to select the module, due to incompatible backend module registration.

This affects all versions that are compatible with TYPO3 CMS v12, see  
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Feature-96733-NewBackendModuleRegistrationAPI.html