### PR TITLE
[BUGFIX] CiteStyle fixes

### DIFF
--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -64,7 +64,6 @@
 	<f:render section="howpublished" arguments="{_all}"/>
 	<f:render section="publisher" arguments="{_all}"/>
 	<f:render section="date_year-month" arguments="{_all}"/>
-	<f:render section="howpublished" arguments="{_all}"/>
 	<f:render section="affiliation"  arguments="{_all}"/>
 	<f:render section="linkblock" arguments="{_all}"/>
 </f:section>
@@ -161,7 +160,6 @@
 	<f:render section="eventplace"  arguments="{_all}"/>
 	<f:render section="eventdate"  arguments="{_all}"/>
 	<f:render section="organization"  arguments="{_all}"/>
-	<f:render section="editor_simple"  arguments="{_all}"/>
 	<f:render section="publisher" arguments="{_all}"/>
 	<f:render section="edition" arguments="{_all}"/>
 	<f:render section="date_year-month" arguments="{_all}"/>
@@ -243,7 +241,6 @@
 	<f:render section="language"  arguments="{_all}"/>
 	<f:render section="authors" arguments="{_all}"/>
 	<f:render section="title" arguments="{_all}"/>
-	<f:render section="editor_simple"  arguments="{_all}"/>
 	<f:render section="affiliation"  arguments="{_all}"/>
 	<f:render section="organization"  arguments="{_all}"/>
 	<f:render section="pages"  arguments="{_all}"/>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -21,7 +21,7 @@
 
 	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
 		<br/>
-		<f:if condition="{publication.editor}">In {publication.editor}, Editor</f:if><f:if condition="{publication.editor} && {publication.volume}">,</f:if>
+		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.volume}">,</f:if>
 		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>
 		<f:if condition="{publication.series}"><f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if>
 	</f:if>
@@ -127,7 +127,7 @@
 
 	<f:if condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}">
 		<br/>
-		<f:if condition="{publication.editor}">In {publication.editor}, Editor</f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
+		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
 		{publication.booktitle}
 		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>
 		<f:if condition="{publication.series}"><f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -82,7 +82,7 @@
 
 	<f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
 		<br/>
-		{publication.booktitle}<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"><f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} && {publication.pages}">,</f:if>
+		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} && {publication.pages}">,</f:if>
 		<f:if condition="{publication.pages}"><f:translate key="citestyle0.page"/> {publication.pages}</f:if>
 	</f:if>
 
@@ -158,7 +158,7 @@
 		condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
 		<br/>
 		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
-		{publication.booktitle}<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/>{publication.volume}</f:if><f:if condition="{publication.series}"><f:translate key="citestyle0.from"/><i>{publication.series}</i></f:if><f:if condition="({publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}) && {publication.pages}">,</f:if>
+		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="({publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}) && {publication.pages}">,</f:if>
 		<f:if condition="{publication.pages}"><f:translate key="citestyle0.page"/> {publication.pages}</f:if>
 	</f:if>
 

--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -19,7 +19,7 @@
 	<f:render section="authors" arguments="{_all}"/>
 	<f:render section="title" arguments="{_all}"/>
 
-	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
+	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
 		<br/>
 		<f:if condition="{publication.editor}">In {publication.editor}, Editor</f:if><f:if condition="{publication.editor} && {publication.volume}">,</f:if>
 		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>
@@ -40,7 +40,7 @@
 	<f:render section="title" arguments="{_all}"/>
 
 	<f:if
-		condition="{publication.journal} || {publication.volume} || {publication.number} || {publication.pages} || {publication.affiliation}">
+		condition="{publication.journal} || {publication.volume} || {publication.number} || {publication.pages} || {publication.affiliation}">
 		<br/>
 		{publication.journal}<f:if condition="{publication.journal} && {publication.volume}">,</f:if>
 		<f:if condition="{publication.volume}"><strong>{publication.volume}</strong></f:if>
@@ -80,9 +80,9 @@
 	<f:render section="authors" arguments="{_all}"/>
 	<f:render section="title" arguments="{_all}"/>
 
-	<f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
+	<f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
 		<br/>
-		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} && {publication.pages}">,</f:if>
+		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="{publication.booktitle} || {publication.volume} || {publication.series} && {publication.pages}">,</f:if>
 		<f:if condition="{publication.pages}"><f:translate key="citestyle0.page"/> {publication.pages}</f:if>
 	</f:if>
 
@@ -125,9 +125,9 @@
 	<f:render section="authors" arguments="{_all}"/>
 	<f:render section="title" arguments="{_all}"/>
 
-	<f:if condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}">
+	<f:if condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}">
 		<br/>
-		<f:if condition="{publication.editor}">In {publication.editor}, Editor</f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
+		<f:if condition="{publication.editor}">In {publication.editor}, Editor</f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
 		{publication.booktitle}
 		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>
 		<f:if condition="{publication.series}"><f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if>
@@ -155,10 +155,10 @@
 	<f:render section="title" arguments="{_all}"/>
 
 	<f:if
-		condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
+		condition="{publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series} || {publication.pages}">
 		<br/>
-		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
-		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="({publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}) && {publication.pages}">,</f:if>
+		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.booktitle} || {publication.volume}">,</f:if>
+		{publication.booktitle}<f:if condition="{publication.volume}"> <f:translate key="citestyle0.volume"/> {publication.volume}</f:if><f:if condition="{publication.series}"> <f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if><f:if condition="({publication.editor} || {publication.booktitle} || {publication.volume} || {publication.series}) && {publication.pages}">,</f:if>
 		<f:if condition="{publication.pages}"><f:translate key="citestyle0.page"/> {publication.pages}</f:if>
 	</f:if>
 
@@ -516,7 +516,7 @@
 </f:section>
 
 <f:section name="editor_volume_series">
-	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
+	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
 		<br/>
 		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.volume}">,</f:if>
 		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle0.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle0.html
@@ -19,12 +19,7 @@
 	<f:render section="authors" arguments="{_all}"/>
 	<f:render section="title" arguments="{_all}"/>
 
-	<f:if condition="{publication.editor} || {publication.volume} || {publication.series}">
-		<br/>
-		<f:if condition="{publication.editor}">In {publication.editor}, <f:translate key="citestyle0.editor"/></f:if><f:if condition="{publication.editor} && {publication.volume}">,</f:if>
-		<f:if condition="{publication.volume}"><f:translate key="citestyle0.volume"/> {publication.volume}</f:if>
-		<f:if condition="{publication.series}"><f:translate key="citestyle0.from"/> <i>{publication.series}</i></f:if>
-	</f:if>
+	<f:render section="editor_volume_series" arguments="{_all}"/>
 
 	<f:render section="publisher" arguments="{_all}"/>
 	<f:render section="edition" arguments="{_all}"/>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle1.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle1.html
@@ -50,7 +50,6 @@
 
 <f:section name="bibtype_book">
 	<f:if condition="{publication.language}">[{publication.language}]</f:if>
-	....
 	<f:render section="authors" arguments="{_all}"/>
 	<f:if condition="{publication.title}"><i>{publication.title}.</i></f:if>
 	<f:if condition="{publication.edition}">{publication.edition}</f:if>

--- a/Resources/Private/Partials/List/Citestyle/Citestyle1.html
+++ b/Resources/Private/Partials/List/Citestyle/Citestyle1.html
@@ -50,8 +50,9 @@
 
 <f:section name="bibtype_book">
 	<f:if condition="{publication.language}">[{publication.language}]</f:if>
-	<f:render section="authors" arguments="{_all}"/><f:if condition="{publication.title}"><i>{publication.title}.</i></f:if>
 	....
+	<f:render section="authors" arguments="{_all}"/>
+	<f:if condition="{publication.title}"><i>{publication.title}.</i></f:if>
 	<f:if condition="{publication.edition}">{publication.edition}</f:if>
 	<f:if condition="{publication.address}">{publication.address}<f:if condition="{publication.publisher}"><f:then>:</f:then><f:else><f:if condition="{publication.month} || {publication.year}"><f:then>,</f:then><f:else>.</f:else></f:if></f:else></f:if></f:if>
 	<f:if condition="{publication.publisher}">{publication.publisher}<f:if condition="{publication.month} || {publication.year}"><f:then>,</f:then><f:else>.</f:else></f:if></f:if>
@@ -152,7 +153,8 @@
 
 <f:section name="bibtype_misc">
 	<f:if condition="{publication.language}">[{publication.language}]</f:if>
-	<f:render section="authors" arguments="{_all}"/><f:if condition="{publication.title}"><i>{publication.title}</i><f:if condition="{publication.month} || {publication.year}"><f:then>,</f:then><f:else>.</f:else></f:if></f:if>
+	<f:render section="authors" arguments="{_all}"/>
+	<f:if condition="{publication.title}"><i>{publication.title}</i><f:if condition="{publication.month} || {publication.year}"><f:then>,</f:then><f:else>.</f:else></f:if></f:if>
 	<f:if condition="{publication.month} || {publication.year}">
 		<publications:format.monthNameFromNumber month="{publication.month}" limit="3"/>
 		{publication.year}.


### PR DESCRIPTION
# Changes

* Add missing spaces between words
* Use regular spaces instead of non-breaking spaces in fluid conditions
* Translate the word "Editor"
* Output parameters only once in each section

---

I might have missed some errors, but the suggested changes should already be an improvement on the default templates