### PR TITLE
[BUGFIX] Use existing parameter

### DIFF
--- a/Classes/Service/ImportService.php
+++ b/Classes/Service/ImportService.php
@@ -215,10 +215,10 @@ class ImportService extends AbstractService
 
         $currentPublication = $this->getPublicationByIdentifier(
             $this->storagePid,
-            $updatedPublication['title'] ?? '',
-            $updatedPublication['year'] ?? '',
-            $updatedPublication['citeid'] ?? '',
-            $updatedPublication['bibtype'] ?? '',
+            $record['title'] ?? '',
+            $record['year'] ?? '',
+            $record['citeid'] ?? '',
+            $record['bibtype'] ?? '',
         );
 
         if (!empty($currentPublication)) {


### PR DESCRIPTION
# Issue

Changes introduced in b8724b1fbcd9996aa05381d77da9a2373c1725f6 use a variable that is not defined anywhere in the `addOrUpdatePublication` method. 

It's probably a simple copy&paste error.

# Changes

Use the right parameters name.