### PR TITLE
Test for array key in TCA pages override

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -9,7 +9,7 @@ $iconRef = 'extension-' . $ext;
 
 $addToModuleSelection = true;
 foreach ($GLOBALS['TCA']['pages']['columns']['module']['config']['items'] as $item) {
-    if ($item['1'] == $ext || $item['value'] === $ext) {
+    if ((array_key_exists('1', $item) && $item['1'] == $ext) || $item['value'] === $ext) {
         $addToModuleSelection = false;
         break;
     }


### PR DESCRIPTION
This fixes an error in TYPO3 12, when the array key '1' does not exist in the pages TCA.